### PR TITLE
Fix animation not working on non-WebKit browsers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,9 +61,17 @@ h1{
   from { -webkit-transform: rotateY(0); -moz-transform: rotateY(0); transform: rotateY(0); }
   to { -webkit-transform: rotateY(1800deg); -moz-transform: rotateY(1800deg); transform: rotateY(1800deg); }
 }
+@keyframes flipHeads {
+  from { transform: rotateY(0); }
+  to { transform: rotateY(1800deg); }
+}
 @-webkit-keyframes flipTails {
   from { -webkit-transform: rotateY(0); -moz-transform: rotateY(0); transform: rotateY(0); }
   to { -webkit-transform: rotateY(1980deg); -moz-transform: rotateY(1980deg); transform: rotateY(1980deg); }
+}
+@keyframes flipTails {
+  from { transform: rotateY(0); }
+  to { transform: rotateY(1980deg); }
 }
 
 .v-center-flex {


### PR DESCRIPTION
## Summary
- support standard CSS animations by defining unprefixed `@keyframes`

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_684cb75fdcc0832281b7feb9044dc41f